### PR TITLE
ci: 1、精简开发目录;

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ coverage
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json
+!.vscode/settings.json
 .idea
 *.suo
 *.ntvs*

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,5 @@
 {
   "recommendations": [
-    "Vue.vscode-typescript-vue-plugin",
     "dbaeumer.vscode-eslint",
     "esbenp.prettier-vscode"
   ]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,12 @@
+{
+  "explorer.fileNesting.enabled": true,
+  "explorer.fileNesting.expand": false,
+  "explorer.fileNesting.patterns": {
+    ".env.dev": "$(capture).env.*",
+    "README.md": "README*,CHANGELOG*,LICENSE,CNAME",
+    "package.json": "pnpm-lock.yaml,pnpm-workspace.yaml,.gitattributes,.gitignore,.gitpod.yml,.npmrc,.browserslistrc,.node-version,.git*,.tazerc.json,package-lock.json,plopfile.js",
+    "eslint.config.js": ".commitlintrc.cjs,.stylelintrc.json,.lintstagedrc,.versionrc,.prettierrc.json",
+    "env.d.ts": "auto-imports.d.ts, components.d.ts",
+    "vite.config.ts": "vitest.config.ts"
+  }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,9 +4,9 @@
   "explorer.fileNesting.patterns": {
     ".env.dev": "$(capture).env.*",
     "README.md": "README*,CHANGELOG*,LICENSE,CNAME",
-    "package.json": "pnpm-lock.yaml,pnpm-workspace.yaml,.gitattributes,.gitignore,.gitpod.yml,.npmrc,.browserslistrc,.node-version,.git*,.tazerc.json,package-lock.json,plopfile.js",
+    "package.json": "pnpm-lock.yaml,pnpm-workspace.yaml,.gitignore,.npmrc,.browserslistrc,package-lock.json,plopfile.js,index.html",
     "eslint.config.js": ".commitlintrc.cjs,.stylelintrc.json,.lintstagedrc,.versionrc,.prettierrc.json",
     "env.d.ts": "auto-imports.d.ts, components.d.ts",
-    "vite.config.ts": "vitest.config.ts"
+    "vite.config.ts": "vitest.config.ts,uno.config.ts"
   }
 }


### PR DESCRIPTION
ci: 
1、精简开发目录;
<img width="484" alt="image" src="https://github.com/user-attachments/assets/22505d4a-3452-4b6d-8bdf-e0cf1cbdbaed" />

2、删除 Vue.vscode-typescript-vue-plugin 插件的安装提示（该插件官方已经废弃）；
<img width="1271" alt="image" src="https://github.com/user-attachments/assets/0e531361-514f-46ba-a3bd-600035747abe" />
